### PR TITLE
Fix deprecation notice

### DIFF
--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -2,7 +2,7 @@
 
 namespace HarmBandstra\SwaggerUiBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class DocsController extends Controller
+class DocsController extends AbstractController
 {
     /**
      * @param Request $request


### PR DESCRIPTION
1x: The "HarmBandstra\SwaggerUiBundle\Controller\DocsController" class extends "Symfony\Bundle\FrameworkBundle\Controller\Controller" that is deprecated since Symfony 4.2, use {@see AbstractController} instead.