### PR TITLE
#14 Exclude map files from copy of assets

### DIFF
--- a/src/Composer/ScriptHandler.php
+++ b/src/Composer/ScriptHandler.php
@@ -4,6 +4,7 @@ namespace HarmBandstra\SwaggerUiBundle\Composer;
 
 use Composer\Script\Event;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 class ScriptHandler
 {
@@ -18,7 +19,10 @@ class ScriptHandler
         $source = sprintf('%s/swagger-api/swagger-ui/dist', $vendorDir);
         $target = sprintf('%s/harmbandstra/swagger-ui-bundle/src/Resources/public', $vendorDir);
 
-        $filesystem->mirror($source, $target, null, ['override' => true]);
+        $exclude = new Finder();
+        $exclude->files()->in($source)->notName('*.map');
+
+        $filesystem->mirror($source, $target, $exclude, ['override' => true]);
 
         $event->getIO()->write('Linked SwaggerUI assets.');
     }


### PR DESCRIPTION
Fix for https://github.com/harmbandstra/swagger-ui-bundle/issues/14 - stop large map files being copied with assets.