### PR TITLE
assets option added

### DIFF
--- a/src/Controller/DocsController.php
+++ b/src/Controller/DocsController.php
@@ -22,11 +22,15 @@ class DocsController extends AbstractController
     /** @var string */
     private $directory;
 
-    public function __construct($projectDir, $swaggerFiles, $directory)
+    /** @var string */
+    private $assets;
+
+    public function __construct($projectDir, $swaggerFiles, $directory, $assets)
     {
         $this->projectDir = $projectDir;
         $this->swaggerFiles = $swaggerFiles;
         $this->directory = $directory;
+        $this->assets = $assets;
     }
 
     /**
@@ -64,7 +68,10 @@ class DocsController extends AbstractController
         }
 
         // redirect to the assets dir so that relative links work
-        return $this->redirect('/bundles/hbswaggerui/' . $fileName);
+        if($this->assets != '') {
+            return $this->redirect( $this->assets . $fileName);
+        }
+        return $this->redirect( '/bundles/hbswaggerui/' . $fileName);
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -20,6 +20,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('directory')->defaultValue('')->end()
+                ->scalarNode('assets')->defaultValue('')->end()
                 ->arrayNode('files')->isRequired()->prototype('scalar')->end()
             ->end()
         ;

--- a/src/DependencyInjection/HBSwaggerUiExtension.php
+++ b/src/DependencyInjection/HBSwaggerUiExtension.php
@@ -15,6 +15,7 @@ class HBSwaggerUiExtension extends Extension
 
         $container->setParameter('hb_swagger_ui.directory', $config['directory']);
         $container->setParameter('hb_swagger_ui.files', $config['files']);
+        $container->setParameter('hb_swagger_ui.assets', $config['assets']);
 
         $loader = new YamlFileLoader(
             $container,

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -8,3 +8,4 @@ services:
       $projectDir: '%kernel.project_dir%'
       $swaggerFiles: '%hb_swagger_ui.files%'
       $directory: '%hb_swagger_ui.directory%'
+      $assets: '%hb_swagger_ui.assets%'


### PR DESCRIPTION
Hello!
Last time when this bundle was used by me I had an issue.
It was nessesery to set up custom route to bundle asserts.
So I desided to add some mods to code. Then I thouth that this feature can be useful fo someone else.

With my mods file `config/packages/hb_swagger_ui.yaml` will be looks like this:

`hb_swagger_ui:`
  `directory: "%kernel.root_dir%"`
 ` assets: "/custom-assets-directory/hbswaggerui/"  # manual set up of assets`
 ` files:`
  ` - "/docs/swagger.yml"`

If assets parameter is not setted it is equels to default value (/bundles/hbswaggerui/)

For example of usage of modded bundle You can check [this repository](https://github.com/OleksandrProtsiuk/swagger-ui-bundle) or contact me to get more details.