### PR TITLE
added support for swagger UI config file

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('directory')->defaultValue('')->end()
                 ->scalarNode('assetUrlPath')->defaultValue('/bundles/hbswaggerui/')->end()
+                ->scalarNode('configFile')->defaultNull()->end()
                 ->arrayNode('files')->isRequired()->prototype('scalar')->end()
             ->end()
         ;

--- a/src/DependencyInjection/HBSwaggerUiExtension.php
+++ b/src/DependencyInjection/HBSwaggerUiExtension.php
@@ -16,6 +16,7 @@ class HBSwaggerUiExtension extends Extension
         $container->setParameter('hb_swagger_ui.directory', $config['directory']);
         $container->setParameter('hb_swagger_ui.files', $config['files']);
         $container->setParameter('hb_swagger_ui.assetUrlPath', $config['assetUrlPath']);
+        $container->setParameter('hb_swagger_ui.configFile', $config['configFile']);
 
         $loader = new YamlFileLoader(
             $container,

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -9,3 +9,4 @@ services:
       $swaggerFiles: '%hb_swagger_ui.files%'
       $directory: '%hb_swagger_ui.directory%'
       $assetUrlPath: '%hb_swagger_ui.assetUrlPath%'
+      $configFile: '%hb_swagger_ui.configFile%'

--- a/tests/Resources/config/config.yml
+++ b/tests/Resources/config/config.yml
@@ -11,6 +11,7 @@ framework:
 
 hb_swagger_ui:
   directory: "%kernel.project_dir%/tests/Resources/docs/"
+  configFile: "config.json"
   files:
       - "petstore.json"
       - "petstore.yaml"

--- a/tests/Resources/docs/config.json
+++ b/tests/Resources/docs/config.json
@@ -1,0 +1,10 @@
+{
+  "dom_id": "#swagger-ui",
+  "deepLinking": true,
+  "displayRequestDuration": true,
+  "docExpansion": "none",
+  "operationsSorter": "alpha",
+  "showCommonExtensions": true,
+  "syntaxHighlight.theme": "nord",
+  "persistAuthorization": true
+}


### PR DESCRIPTION
Following up on https://github.com/harmbandstra/swagger-ui-bundle/issues/21 here's a first take on this. Please have a look and let me know if that makes sense.

The regular expression against the `index.html` isn't ideal, but I think it's probably still the best way to make it work even with upstream changes.
I wasn't able to move all the config to the config file, e.g. layout and presets, seems these need to be in the actual file to work - the configFile is loaded too late for it to work I guess.